### PR TITLE
Fixed get-stack.sh script to match manual instructions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -47,6 +47,8 @@ Other enhancements:
 
 Bug fixes:
 
+* The `get-stack.sh` install script now matches manual instructions
+  when it comes to Debian/Fedora/CentOS install dependencies.
 
 
 ## v1.6.5

--- a/etc/scripts/get-stack.sh
+++ b/etc/scripts/get-stack.sh
@@ -164,7 +164,7 @@ do_ubuntu_install() {
 do_debian_install() {
 
   install_dependencies() {
-    apt_install_dependencies g++ gcc libc6-dev libffi-dev libgmp-dev make xz-utils zlib1g-dev
+    apt_install_dependencies g++ gcc libc6-dev libffi-dev libgmp-dev make xz-utils zlib1g-dev git gnupg
   }
 
   if is_arm ; then
@@ -188,7 +188,7 @@ do_debian_install() {
 # and install the necessary dependencies explicitly.
 do_fedora_install() {
   install_dependencies() {
-    dnf_install_pkgs perl make automake gcc gmp-devel libffi zlib xz tar
+    dnf_install_pkgs perl make automake gcc gmp-devel libffi zlib xz tar git gnupg
   }
 
   if is_64_bit ; then
@@ -208,7 +208,7 @@ do_fedora_install() {
 # and install the necessary dependencies explicitly.
 do_centos_install() {
   install_dependencies() {
-    yum_install_pkgs perl make automake gcc gmp-devel libffi zlib xz tar
+    yum_install_pkgs perl make automake gcc gmp-devel libffi zlib xz tar git gnupg
   }
 
   if is_64_bit ; then


### PR DESCRIPTION
Debian, Fedora and CentOS were missing git and gnupg from the
install dependencies.

Signed-off-by: Tero Laxström <tlax@neonpeons.com>

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [x] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [x] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
